### PR TITLE
replacing json.dumps with flask jsonify

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -111,7 +111,7 @@ def get_transactions():
     entities = request.get_json()['data']['entities']
     transactions = es.get_transactions(entities)
     transactions = [to_ordered_dict(t) for t in transactions]
-    return json.dumps(transactions)
+    return jsonify(transactions)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi Benoit,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for using `json.dumps()` instead of `flask jsonify()`.

I suspect you used `json.dumps()` because you are returning a list. Since 0.11, `jsonify` supports lists so this should be ok.

Otherwise, according to Bento, your project is fairly clean.  If you are interested, feel free download and give Bento a try (https://bento.dev).